### PR TITLE
feat: increase GitHub repository search limit to 30

### DIFF
--- a/frontend/src/api/open-hands.ts
+++ b/frontend/src/api/open-hands.ts
@@ -312,7 +312,7 @@ class OpenHands {
 
   static async searchGitHubRepositories(
     query: string,
-    per_page = 5,
+    per_page = 30,
   ): Promise<GitHubRepository[]> {
     const response = await openHands.get<GitHubRepository[]>(
       "/api/github/search/repositories",

--- a/frontend/src/hooks/query/use-search-repositories.ts
+++ b/frontend/src/hooks/query/use-search-repositories.ts
@@ -4,7 +4,7 @@ import OpenHands from "#/api/open-hands";
 export function useSearchRepositories(query: string) {
   return useQuery({
     queryKey: ["repositories", query],
-    queryFn: () => OpenHands.searchGitHubRepositories(query, 3),
+    queryFn: () => OpenHands.searchGitHubRepositories(query, 30),
     enabled: !!query,
     select: (data) => data.map((repo) => ({ ...repo, is_public: true })),
   });


### PR DESCRIPTION
This PR increases the GitHub repository search limit from 3/5 to 30 repositories to provide a better user experience when searching for repositories.

Changes:
- Increased the search limit in `useSearchRepositories` from 3 to 30
- Increased the default `per_page` parameter in `OpenHands.searchGitHubRepositories` from 5 to 30